### PR TITLE
Add support for to_peer_paserk_id on v1.secret and v3.secret.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Fix bug on calling to_peer_paserk_id on v1/2 local key. `#128 <https://github.com/dajiaji/pyseto/pull/128>`__
 - Add support for to_peer_paserk_id on v1/v3. `#128 <https://github.com/dajiaji/pyseto/pull/128>`__
 
 Version 1.6.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 Unreleased
 ----------
 
+- Add support for to_peer_paserk_id on v1/v3. `#128 <https://github.com/dajiaji/pyseto/pull/128>`__
+
 Version 1.6.5
 -------------
 

--- a/pyseto/key_nist.py
+++ b/pyseto/key_nist.py
@@ -16,8 +16,6 @@ from .exceptions import DecryptError, EncryptError
 from .key_interface import KeyInterface
 from .utils import base64url_decode, base64url_encode
 
-# from .utils import base64url_decode, base64url_encode, ec_public_key_compress
-
 
 class NISTKey(KeyInterface):
     """

--- a/pyseto/key_sodium.py
+++ b/pyseto/key_sodium.py
@@ -227,23 +227,6 @@ class SodiumKey(KeyInterface):
         )
         return h + base64url_encode(priv + pub).decode("utf-8")
 
-    def to_peer_paserk_id(self) -> str:
-        if not self._is_secret:
-            return ""
-
-        h1 = f"k{self.version}.public."
-        pub = self._key.public_key().public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw,
-        )
-        p = h1 + base64url_encode(pub).decode("utf-8")
-
-        h2 = f"k{self.version}.pid."
-        b = hashlib.blake2b(digest_size=33)
-        b.update((h2 + p).encode("utf-8"))
-        d = b.digest()
-        return h2 + base64url_encode(d).decode("utf-8")
-
     @classmethod
     def _encode_pie(cls, header: str, wrapping_key: bytes, ptk: bytes) -> str:
 

--- a/pyseto/versions/v1.py
+++ b/pyseto/versions/v1.py
@@ -239,6 +239,22 @@ class V1Public(NISTKey):
         d = digest.finalize()
         return h + base64url_encode(d[0:33]).decode("utf-8")
 
+    def to_peer_paserk_id(self) -> str:
+        if not self._is_secret:
+            return ""
+
+        k = self._key.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        p = "k1.public." + base64url_encode(k).decode("utf-8")
+
+        h = "k1.pid."
+        digest = hashes.Hash(hashes.SHA384())
+        digest.update((h + p).encode("utf-8"))
+        d = digest.finalize()
+        return h + base64url_encode(d[0:33]).decode("utf-8")
+
     def sign(self, payload: bytes, footer: bytes = b"", implicit_assertion: bytes = b"") -> bytes:
 
         if isinstance(self._key, RSAPublicKey):

--- a/pyseto/versions/v2.py
+++ b/pyseto/versions/v2.py
@@ -4,6 +4,7 @@ from typing import Any, Union
 
 # from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from Cryptodome.Cipher import ChaCha20_Poly1305
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
     Ed25519PublicKey,
@@ -117,6 +118,23 @@ class V2Public(SodiumKey):
         b.update((h + p).encode("utf-8"))
         d = b.digest()
         return h + base64url_encode(d).decode("utf-8")
+
+    def to_peer_paserk_id(self) -> str:
+        if not self._is_secret:
+            return ""
+
+        h1 = "k2.public."
+        pub = self._key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        p = h1 + base64url_encode(pub).decode("utf-8")
+
+        h2 = "k2.pid."
+        b = hashlib.blake2b(digest_size=33)
+        b.update((h2 + p).encode("utf-8"))
+        d = b.digest()
+        return h2 + base64url_encode(d).decode("utf-8")
 
     # @classmethod
     # def from_public_bytes(cls, key: bytes):

--- a/pyseto/versions/v3.py
+++ b/pyseto/versions/v3.py
@@ -258,6 +258,20 @@ class V3Public(NISTKey):
         d = digest.finalize()
         return h + base64url_encode(d[0:33]).decode("utf-8")
 
+    def to_peer_paserk_id(self) -> str:
+        if not self._is_secret:
+            return ""
+
+        pub_key = self._key.public_key()
+        k = ec_public_key_compress(pub_key.public_numbers().x, pub_key.public_numbers().y)
+        p = "k3.public." + base64url_encode(k).decode("utf-8")
+
+        h = "k3.pid."
+        digest = hashes.Hash(hashes.SHA384())
+        digest.update((h + p).encode("utf-8"))
+        d = digest.finalize()
+        return h + base64url_encode(d[0:33]).decode("utf-8")
+
     def sign(self, payload: bytes, footer: bytes = b"", implicit_assertion: bytes = b"") -> bytes:
 
         if isinstance(self._key, EllipticCurvePublicKey):

--- a/pyseto/versions/v4.py
+++ b/pyseto/versions/v4.py
@@ -2,6 +2,7 @@ import hashlib
 from secrets import token_bytes
 from typing import Any, Union
 
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
     Ed25519PublicKey,
@@ -112,6 +113,23 @@ class V4Public(SodiumKey):
         b.update((h + p).encode("utf-8"))
         d = b.digest()
         return h + base64url_encode(d).decode("utf-8")
+
+    def to_peer_paserk_id(self) -> str:
+        if not self._is_secret:
+            return ""
+
+        h1 = "k4.public."
+        pub = self._key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        p = h1 + base64url_encode(pub).decode("utf-8")
+
+        h2 = "k4.pid."
+        b = hashlib.blake2b(digest_size=33)
+        b.update((h2 + p).encode("utf-8"))
+        d = b.digest()
+        return h2 + base64url_encode(d).decode("utf-8")
 
     def sign(self, payload: bytes, footer: bytes = b"", implicit_assertion: bytes = b"") -> bytes:
 

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -140,7 +140,7 @@ class TestV1Public:
     def test_v1_public_to_paserk_id(self):
         sk = Key.new(1, "public", load_key("keys/private_key_rsa.pem"))
         pk = Key.new(1, "public", load_key("keys/public_key_rsa.pem"))
-        assert sk.to_peer_paserk_id() == ""
+        assert sk.to_peer_paserk_id() == pk.to_paserk_id()
         assert pk.to_peer_paserk_id() == ""
 
     def test_v1_public_verify_via_encode_with_wrong_key(self):

--- a/tests/test_v1.py
+++ b/tests/test_v1.py
@@ -131,6 +131,10 @@ class TestV1Local:
             pytest.fail("Key.from_paserk should fail.")
         assert msg in str(err.value)
 
+    def test_v1_local_to_peer_paserk_id(self):
+        k = Key.new(1, "local", b"our-secret")
+        assert k.to_peer_paserk_id() == ""
+
 
 class TestV1Public:
     """

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -177,6 +177,10 @@ class TestV2Local:
             pytest.fail("Key.from_paserk should fail.")
         assert "Failed to unseal a key." in str(err.value)
 
+    def test_v2_local_to_peer_paserk_id(self):
+        k = Key.new(2, "local", token_bytes(32))
+        assert k.to_peer_paserk_id() == ""
+
 
 class TestV2Public:
     """

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -105,6 +105,10 @@ class TestV3Local:
             pytest.fail("Key.from_paserk should fail.")
         assert msg in str(err.value)
 
+    def test_v3_local_to_peer_paserk_id(self):
+        k = Key.new(3, "local", b"our-secret")
+        assert k.to_peer_paserk_id() == ""
+
     # @pytest.mark.parametrize(
     #     "paserk, msg",
     #     [

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -143,7 +143,7 @@ class TestV3Public:
     def test_v3_public_to_paserk_id(self):
         sk = Key.new(3, "public", load_key("keys/private_key_ecdsa_p384.pem"))
         pk = Key.new(3, "public", load_key("keys/public_key_ecdsa_p384.pem"))
-        assert sk.to_peer_paserk_id() == ""
+        assert sk.to_peer_paserk_id() == pk.to_paserk_id()
         assert pk.to_peer_paserk_id() == ""
 
     def test_v3_public_verify_via_encode_with_wrong_key(self):

--- a/tests/test_v4.py
+++ b/tests/test_v4.py
@@ -78,6 +78,10 @@ class TestV4Local:
             pytest.fail("Key.from_paserk should fail.")
         assert msg in str(err.value)
 
+    def test_v4_local_to_peer_paserk_id(self):
+        k = Key.new(4, "local", b"our-secret")
+        assert k.to_peer_paserk_id() == ""
+
 
 class TestV4Public:
     """


### PR DESCRIPTION
Close #127.