### PR TITLE
Compare MACs in constant time

### DIFF
--- a/pyseto/versions/v1.py
+++ b/pyseto/versions/v1.py
@@ -99,7 +99,7 @@ class V1Local(NISTKey):
 
         pre_auth = pae([self.header, n, c, footer])
         t2 = hmac.new(ak, pre_auth, hashlib.sha384).digest()
-        if t != t2:
+        if not hmac.compare_digest(t, t2):
             raise DecryptError("Failed to decrypt.")
         return self._decrypt(ek, n[16:], c)
 

--- a/pyseto/versions/v3.py
+++ b/pyseto/versions/v3.py
@@ -109,7 +109,7 @@ class V3Local(NISTKey):
 
         pre_auth = pae([self.header, n, c, footer, implicit_assertion])
         t2 = hmac.new(ak, pre_auth, hashlib.sha384).digest()
-        if t != t2:
+        if not hmac.compare_digest(t, t2):
             raise DecryptError("Failed to decrypt.")
         return self._decrypt(ek, n2, c)
 

--- a/pyseto/versions/v4.py
+++ b/pyseto/versions/v4.py
@@ -1,4 +1,5 @@
 import hashlib
+import hmac
 from secrets import token_bytes
 from typing import Any, Union
 
@@ -73,7 +74,7 @@ class V4Local(SodiumKey):
         ak = self._generate_hash(self._key, b"paseto-auth-key-for-aead" + n, 32)
         pre_auth = pae([self.header, n, c, footer, implicit_assertion])
         t2 = self._generate_hash(ak, pre_auth, 32)
-        if t != t2:
+        if not hmac.compare_digest(t, t2):
             raise DecryptError("Failed to decrypt.")
         return self._decrypt(ek, n2, c)
 


### PR DESCRIPTION
This PR replaces MAC comparisons using `bytes.__eq__` with calls to `hmac.compare_digest` in the decryption routines for `v1`, `v3` and `v4`, since the PASETO spec requires MACs to be checked in constant time. The `v2` handler delegates this check to `decrypt_and_verify` in PyCryptoDome, [which uses a randomised MAC comparison strategy instead](https://github.com/Legrandin/pycryptodome/blob/5dace638b70ac35bb5d9b565f3e75f7869c9d851/lib/Crypto/Cipher/ChaCha20_Poly1305.py#L235-L236). As such, `v2` didn't require any fixes.

Comments certainly welcome!