### PR TITLE
ci: check uv.lock and requirements.txt stay in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,29 @@ jobs:
     - name: Publish (dry-run)
       run: uv publish --dry-run
 
+  lockfile:
+    name: Check uv.lock and requirements.txt are in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          python-version: "3.13"
+      - name: Check uv.lock resolves pyproject.toml
+        run: uv lock --check
+      - name: Check requirements.txt matches uv.lock
+        run: |
+          uv export --format requirements.txt --all-groups --locked \
+            --no-hashes --no-editable --no-emit-project -o requirements.txt
+          if ! git diff --exit-code requirements.txt; then
+            echo "::error file=requirements.txt::requirements.txt is out of sync with uv.lock. Re-run the export command from README.md and commit the result."
+            exit 1
+          fi
+
   actionlint:
     name: Lint GitHub Actions workflow files
     runs-on: ubuntu-24.04

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Add CI check that uv.lock and requirements.txt stay in sync.
 - Move dependency workflow from Taskfile to native uv config.
 
 Version 1.9.3

--- a/README.md
+++ b/README.md
@@ -490,6 +490,10 @@ $ uv export --format requirements.txt --all-groups --locked \
     --no-hashes --no-editable --no-emit-project -o requirements.txt
 ```
 
+CI fails if `uv.lock` does not resolve `pyproject.toml`, or if `requirements.txt`
+does not match the above export. A dependency bump that edits `requirements.txt`
+without relocking is therefore caught rather than silently scanned.
+
 ### Scanning
 
 ```sh


### PR DESCRIPTION
requirements.txt is a derived artifact, but nothing verified it against uv.lock, and dependabot edits it directly for packages it cannot map into pyproject.toml. When it drifted, security.yml kept auditing it with pip-audit -r, so the scan reported versions that were never installed (#695 bumped python-discovery to 1.4.0 while the lock stayed at 1.3.0).

Deleting requirements.txt would remove the drift entirely, but it exists for Snyk (#554) and the README badge reads it via targetFile. Snyk's uv support is Early Access on Enterprise plans only and does not cover badges, so there is no uv.lock path for this repo today. Gate the file instead.

Two checks, each catching a failure the other misses:

- `uv lock --check` catches a lock regenerated by uv < 0.11, which drops the `[options] exclude-newer` block that `required-version = ">=0.11"` depends on. This is what makes dependabot #715 unmergeable.
- Re-exporting and diffing catches a requirements.txt bumped without a relock. `uv lock --check` passes in that case, since the lock still resolves pyproject.toml.

Both verified against simulated #695- and #715-style commits.