### PR TITLE
chore: run ruff from the dev group instead of a second pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,20 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+  # Run ruff from the dev dependency group. A ruff-pre-commit `rev` would be a
+  # second pin that dependabot never touches, so it would drift from uv.lock.
+  - repo: local
     hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-check
+        name: ruff check
+        entry: uv run --frozen ruff check --force-exclude --fix --exit-non-zero-on-fix
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true
       - id: ruff-format
+        name: ruff format
+        entry: uv run --frozen ruff format --force-exclude
+        language: system
+        types_or: [python, pyi, jupyter]
+        require_serial: true
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.19.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Run ruff from the dev dependency group instead of a separate pre-commit pin.
 - Add CI check that uv.lock and requirements.txt stay in sync.
 - Move dependency workflow from Taskfile to native uv config.
 


### PR DESCRIPTION
ruff was pinned twice: `ruff-pre-commit` at rev v0.14.10 and the dev dependency group, which uv.lock tracked at 0.15.21. CI lints via `pre-commit run --all-files`, so it was linting with 0.14.10 while `uv run ruff` locally used 0.15.21 — the two could disagree on the same file.

Bumping the rev would only realign it for a day. Dependabot bumps ruff in uv.lock continuously, but has never touched .pre-commit-config.yaml; the v0.14.10 rev is from a manual commit in 2025-12 and had drifted about seven months. Replace the remote hook with local hooks that shell out to `uv run --frozen ruff`, leaving uv.lock as the single source of truth.

`--force-exclude` matches what ruff-pre-commit passes, so ruff keeps honouring its own exclude config when pre-commit hands it explicit paths.

pre-commit.ci would not have uv available for `language: system` hooks, but it stopped running here in 2025-12 and the config has no `ci:` section.

CI now lints with 0.15.21. All hooks and 504 tests pass.