### PR TITLE
fix(key): enforce mandated key type for v1.public and v3.public

### DIFF
--- a/pyseto/versions/v1.py
+++ b/pyseto/versions/v1.py
@@ -115,6 +115,11 @@ class V1Public(NISTKey):
         self._sig_size = 256
         if not isinstance(self._key, (RSAPublicKey, RSAPrivateKey)):
             raise ValueError("The key is not RSA key.")
+        if self._key.key_size != 2048:
+            raise ValueError("The RSA key size must be 2048 bits.")
+        pub = self._key if isinstance(self._key, RSAPublicKey) else self._key.public_key()
+        if pub.public_numbers().e != 65537:
+            raise ValueError("The RSA public exponent must be 65537.")
 
         if isinstance(self._key, RSAPublicKey):
             self._is_secret = False

--- a/pyseto/versions/v3.py
+++ b/pyseto/versions/v3.py
@@ -133,6 +133,8 @@ class V3Public(NISTKey):
         self._sig_size = 96
         if not isinstance(self._key, (EllipticCurvePublicKey, EllipticCurvePrivateKey)):
             raise ValueError("The key is not ECDSA key.")
+        if not isinstance(self._key.curve, ec.SECP384R1):
+            raise ValueError("The key is not on curve P-384.")
 
         if isinstance(self._key, EllipticCurvePublicKey):
             self._is_secret = False

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -2,7 +2,7 @@ from secrets import token_bytes
 
 import pytest
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
 
 from pyseto import DecryptError, Key, NotSupportedError
@@ -126,6 +126,70 @@ class TestKey:
             Key.new(version, "public", key)
             pytest.fail("Key.new should fail.")
         assert msg in str(err.value)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            load_key("keys/private_key_rsa_4096.pem"),
+            load_key("keys/public_key_rsa_4096.pem"),
+        ],
+    )
+    def test_key_new_v1_public_with_non_2048_rsa_key(self, key):
+        # PASETO v1.public mandates a 2048-bit RSA key; _sig_size is fixed at 256
+        # bytes accordingly, so other sizes must be rejected up front.
+        with pytest.raises(ValueError) as err:
+            Key.new(1, "public", key)
+            pytest.fail("Key.new should fail.")
+        assert "The RSA key size must be 2048 bits." in str(err.value)
+
+    @pytest.mark.parametrize(
+        "curve",
+        [
+            ec.SECP256R1(),
+            ec.SECP521R1(),
+        ],
+    )
+    def test_key_new_v3_public_with_non_p384_key(self, curve):
+        # PASETO v3.public mandates curve P-384; _sig_size is fixed at 96 bytes
+        # accordingly, so keys on other curves must be rejected up front.
+        sk = ec.generate_private_key(curve)
+        for pem in (
+            sk.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            ),
+            sk.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ),
+        ):
+            with pytest.raises(ValueError) as err:
+                Key.new(3, "public", pem)
+                pytest.fail("Key.new should fail.")
+            assert "The key is not on curve P-384." in str(err.value)
+
+    def test_key_new_v1_public_with_non_65537_exponent(self):
+        # PASETO v1.public mandates RSASSA-PSS with public exponent 65537. A
+        # 2048-bit key with a different exponent (here e=3) otherwise passes the
+        # size check and produces a 256-byte signature, so it must be rejected up
+        # front -- for both the private and the public half of the key.
+        sk = rsa.generate_private_key(public_exponent=3, key_size=2048)
+        for pem in (
+            sk.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            ),
+            sk.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ),
+        ):
+            with pytest.raises(ValueError) as err:
+                Key.new(1, "public", pem)
+                pytest.fail("Key.new should fail.")
+            assert "The RSA public exponent must be 65537." in str(err.value)
 
     @pytest.mark.parametrize(
         "version, purpose, key, msg",


### PR DESCRIPTION
PASETO fixes the algorithm per version, and this library hard-codes the resulting signature sizes (v1.public: 256-byte RSASSA-PSS, v3.public: 96-byte P-384 ECDSA). The constructors only checked the key *family*, so a 4096-bit RSA key or a P-256/P-521 EC key was accepted and then silently produced signatures that could never verify against the fixed size.

Reject them at construction: require a 2048-bit modulus for v1.public and curve P-384 for v3.public.

BREAKING CHANGE: v1.public keys that are not 2048-bit RSA and v3.public keys not on curve P-384 are now rejected by Key.new()/from_paserk() instead of being accepted. Such keys were never PASETO-compliant and could not produce verifiable tokens.